### PR TITLE
feat: 添加了 Google Gemini AI 模型的支持

### DIFF
--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -237,6 +237,8 @@ func runRelay(cmd *cobra.Command, args []string) {
 			modelName = "deepseek-chat"
 		case "kimi", "moonshot":
 			modelName = "moonshot-v1-8k"
+		case "gemini":
+			modelName = "gemini-2.0-flash-exp"
 		default:
 			modelName = "claude-sonnet-4-20250514"
 		}

--- a/internal/agent/provider_gemini.go
+++ b/internal/agent/provider_gemini.go
@@ -1,0 +1,280 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	geminiDefaultBaseURL = "https://generativelanguage.googleapis.com/v1beta"
+	geminiDefaultModel   = "gemini-2.0-flash-exp"
+)
+
+// GeminiProvider implements the Provider interface for Google Gemini
+type GeminiProvider struct {
+	apiKey  string
+	baseURL string
+	model   string
+	client  *http.Client
+}
+
+// GeminiConfig holds Gemini provider configuration
+type GeminiConfig struct {
+	APIKey  string
+	BaseURL string
+	Model   string
+}
+
+// NewGeminiProvider creates a new Gemini provider
+func NewGeminiProvider(cfg GeminiConfig) (*GeminiProvider, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+
+	if cfg.Model == "" {
+		cfg.Model = geminiDefaultModel
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = geminiDefaultBaseURL
+	}
+
+	return &GeminiProvider{
+		apiKey:  cfg.APIKey,
+		baseURL: baseURL,
+		model:   cfg.Model,
+		client:  &http.Client{},
+	}, nil
+}
+
+// Name returns the provider name
+func (p *GeminiProvider) Name() string {
+	return "gemini"
+}
+
+// Gemini API request/response structures
+type geminiRequest struct {
+	Contents         []geminiContent   `json:"contents"`
+	SystemInstruction *geminiContent   `json:"systemInstruction,omitempty"`
+	Tools            []geminiTool      `json:"tools,omitempty"`
+	GenerationConfig *generationConfig `json:"generationConfig,omitempty"`
+}
+
+type geminiContent struct {
+	Role  string        `json:"role,omitempty"`
+	Parts []geminiPart  `json:"parts"`
+}
+
+type geminiPart struct {
+	Text         string              `json:"text,omitempty"`
+	FunctionCall *geminiFunctionCall `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+type geminiFunctionCall struct {
+	Name string         `json:"name"`
+	Args map[string]any `json:"args"`
+}
+
+type geminiFunctionResponse struct {
+	Name     string         `json:"name"`
+	Response map[string]any `json:"response"`
+}
+
+type geminiTool struct {
+	FunctionDeclarations []geminiFunctionDeclaration `json:"functionDeclarations"`
+}
+
+type geminiFunctionDeclaration struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+
+type generationConfig struct {
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty"`
+}
+
+type geminiResponse struct {
+	Candidates []geminiCandidate `json:"candidates"`
+}
+
+type geminiCandidate struct {
+	Content       geminiContent `json:"content"`
+	FinishReason  string        `json:"finishReason"`
+}
+
+// Chat sends messages and returns a response
+func (p *GeminiProvider) Chat(ctx context.Context, req ChatRequest) (ChatResponse, error) {
+	// Build Gemini request
+	gemReq := geminiRequest{
+		Contents: make([]geminiContent, 0),
+		GenerationConfig: &generationConfig{
+			MaxOutputTokens: req.MaxTokens,
+		},
+	}
+
+	// Add system instruction
+	if req.SystemPrompt != "" {
+		gemReq.SystemInstruction = &geminiContent{
+			Parts: []geminiPart{{Text: req.SystemPrompt}},
+		}
+	}
+
+	// Convert messages to Gemini format
+	for _, msg := range req.Messages {
+		gemReq.Contents = append(gemReq.Contents, p.toGeminiContent(msg))
+	}
+
+	// Convert tools to Gemini format
+	if len(req.Tools) > 0 {
+		declarations := make([]geminiFunctionDeclaration, 0, len(req.Tools))
+		for _, tool := range req.Tools {
+			var params map[string]any
+			if err := json.Unmarshal(tool.InputSchema, &params); err != nil {
+				params = map[string]any{"type": "object"}
+			}
+			declarations = append(declarations, geminiFunctionDeclaration{
+				Name:        tool.Name,
+				Description: tool.Description,
+				Parameters:  params,
+			})
+		}
+		gemReq.Tools = []geminiTool{{FunctionDeclarations: declarations}}
+	}
+
+	// Build URL
+	url := fmt.Sprintf("%s/models/%s:generateContent", p.baseURL, p.model)
+
+	// Marshal request
+	reqBody, err := json.Marshal(gemReq)
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-goog-api-key", p.apiKey)
+
+	// Send request
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		return ChatResponse{}, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	// Parse response
+	var gemResp geminiResponse
+	if err := json.Unmarshal(respBody, &gemResp); err != nil {
+		return ChatResponse{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return p.fromGeminiResponse(gemResp), nil
+}
+
+// toGeminiContent converts a generic Message to Gemini format
+func (p *GeminiProvider) toGeminiContent(msg Message) geminiContent {
+	content := geminiContent{
+		Parts: make([]geminiPart, 0),
+	}
+
+	switch msg.Role {
+	case "user":
+		content.Role = "user"
+		if msg.ToolResult != nil {
+			// Tool result message
+			content.Parts = append(content.Parts, geminiPart{
+				FunctionResponse: &geminiFunctionResponse{
+					Name: msg.ToolResult.ToolCallID, // Use as function name
+					Response: map[string]any{
+						"result": msg.ToolResult.Content,
+					},
+				},
+			})
+		} else {
+			content.Parts = append(content.Parts, geminiPart{Text: msg.Content})
+		}
+
+	case "assistant":
+		content.Role = "model"
+		if msg.Content != "" {
+			content.Parts = append(content.Parts, geminiPart{Text: msg.Content})
+		}
+		// Add function calls
+		for _, tc := range msg.ToolCalls {
+			var args map[string]any
+			json.Unmarshal(tc.Input, &args)
+			content.Parts = append(content.Parts, geminiPart{
+				FunctionCall: &geminiFunctionCall{
+					Name: tc.Name,
+					Args: args,
+				},
+			})
+		}
+
+	default:
+		content.Role = "user"
+		content.Parts = append(content.Parts, geminiPart{Text: msg.Content})
+	}
+
+	return content
+}
+
+// fromGeminiResponse converts Gemini response to generic format
+func (p *GeminiProvider) fromGeminiResponse(resp geminiResponse) ChatResponse {
+	if len(resp.Candidates) == 0 {
+		return ChatResponse{}
+	}
+
+	candidate := resp.Candidates[0]
+	var content string
+	var toolCalls []ToolCall
+
+	for _, part := range candidate.Content.Parts {
+		if part.Text != "" {
+			content += part.Text
+		}
+		if part.FunctionCall != nil {
+			// Convert function call to tool call
+			argsJSON, _ := json.Marshal(part.FunctionCall.Args)
+			toolCalls = append(toolCalls, ToolCall{
+				ID:    part.FunctionCall.Name, // Gemini doesn't provide IDs, use name
+				Name:  part.FunctionCall.Name,
+				Input: argsJSON,
+			})
+		}
+	}
+
+	finishReason := "stop"
+	if len(toolCalls) > 0 {
+		finishReason = "tool_use"
+	}
+
+	return ChatResponse{
+		Content:      content,
+		ToolCalls:    toolCalls,
+		FinishReason: finishReason,
+	}
+}


### PR DESCRIPTION
主要更改：
- 新增 `internal/agent/provider_gemini.go` 实现 Gemini provider。
- 修改 `internal/agent/agent.go` 注册 provider。
- 更新 `cmd/relay.go` 相关配置。

使用方法:
  lingti-bot relay --provider gemini --api-key GEMINI_KEY